### PR TITLE
Fix to remove old items

### DIFF
--- a/dist/knockout-fast-foreach.js
+++ b/dist/knockout-fast-foreach.js
@@ -167,9 +167,10 @@ FastForEach.prototype.added = function (index, value) {
 FastForEach.prototype.deleted = function (index, value) {
   var ptr = this.lastNodesList[index],
       lastNode = this.lastNodesList[index + 1];
-  this.element.removeChild(ptr);
-  while ((ptr = ptr.nextSibling) && ptr !== lastNode) {
+  while (ptr && ptr !== lastNode) {
+    var nextSibling = ptr.nextSibling;
     this.element.removeChild(ptr);
+    ptr = nextSibling;
   }
   this.indexesToDelete.push(index);
 };


### PR DESCRIPTION
The item was being removed from the DOM meaning `ptr.nextSibling` returned null rather than the intended next sibling. Therefore we need to capture `ptr.nextSibling` before `ptr` is removed then apply it to `ptr` after. 

There might well be a better way to organise the while loop but this fixes the issue at hand.
