### PR TITLE
Add ability to reuse DOM nodes when array items move, closes #33

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,8 +95,11 @@ function FastForEach(spec) {
   this.rendering_queued = false;
   this.pendingDeletes = [];
   // for testability purposes only
-  if (FastForEach.DEBUG)
+  if (FastForEach.DEBUG) {
     this.manualProcessChangeQueue = spec.manualProcessChangeQueue;
+    // expose our symbol for tests
+    FastForEach.PENDING_DELETE_INDEX_KEY = PENDING_DELETE_INDEX_KEY;
+  }
 
   // Remove existing content.
   ko.virtualElements.emptyNode(this.element);
@@ -395,9 +398,9 @@ FastForEach.prototype.flushPendingDeletes = function () {
   for (var i = 0; i != this.pendingDeletes.length; ++i) {
     while (this.pendingDeletes[i].nodesets.length) {
       this.removeNodes(this.pendingDeletes[i].nodesets.pop());
-      if (this.pendingDeletes[i].data && typeof this.pendingDeletes[i].data[PENDING_DELETE_INDEX_KEY] !== "undefined")
-        delete this.pendingDeletes[i].data[PENDING_DELETE_INDEX_KEY];
     }
+    if (this.pendingDeletes[i].data && typeof this.pendingDeletes[i].data[PENDING_DELETE_INDEX_KEY] !== "undefined")
+      delete this.pendingDeletes[i].data[PENDING_DELETE_INDEX_KEY];
   }
   arrayClear(this.pendingDeletes);
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// index.js
+﻿// index.js
 // --------
 // Fast For Each
 //
@@ -297,7 +297,7 @@ FastForEach.prototype.insertAllAfter = function (nodeOrNodeArrayToInsert, insert
     containerNode = this.element;
 
   // poor man's node and array check, should be enough for this
-  if (typeof nodeOrNodeArrayToInsert.nodeType !== "undefined" && typeof nodeOrNodeArrayToInsert.length === "undefined") {
+  if (typeof nodeOrNodeArrayToInsert.nodeType === "undefined" && typeof nodeOrNodeArrayToInsert.length === "undefined") {
     throw new Error("Expected a single node or a node array");
   }
   if (typeof nodeOrNodeArrayToInsert.nodeType !== "undefined") {
@@ -326,7 +326,7 @@ FastForEach.prototype.insertAllAfter = function (nodeOrNodeArrayToInsert, insert
 
 // checks if the deleted data item should be handled with delay for a possible reuse at additions
 FastForEach.prototype.shouldDelayDeletion = function (data) {
-  return this.allowMoveNodes && typeof data === "object" || typeof data === "function";
+  return this.allowMoveNodes && (typeof data === "object" || typeof data === "function");
 }
 
 // get the cached index from the data item which points to its pendind deletion info

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function FastForEach(spec) {
   this.afterAdd = spec.afterAdd;
   this.beforeRemove = spec.beforeRemove;
   this.templateNode = makeTemplateNode(
-    spec.name ? document.getElementById(spec.name).cloneNode(true) : spec.element
+    spec.templateNode || (spec.name ? document.getElementById(spec.name).cloneNode(true) : spec.element)
   );
   this.afterQueueFlush = spec.afterQueueFlush;
   this.beforeQueueFlush = spec.beforeQueueFlush;
@@ -283,10 +283,10 @@ FastForEach.prototype.insertAllAfter = function (nodeOrNodeArrayToInsert, insert
     containerNode = this.element;
 
   // poor man's node and array check, should be enough for this
-  if (typeof nodeOrNodeArrayToInsert.nodeType === "undefined" && typeof nodeOrNodeArrayToInsert.length === "undefined") {
+  if (nodeOrNodeArrayToInsert.nodeType === undefined && nodeOrNodeArrayToInsert.length === undefined) {
     throw new Error("Expected a single node or a node array");
   }
-  if (typeof nodeOrNodeArrayToInsert.nodeType !== "undefined") {
+  if (nodeOrNodeArrayToInsert.nodeType !== undefined) {
     ko.virtualElements.insertAfter(containerNode, nodeOrNodeArrayToInsert, insertAfterNode);
     return [nodeOrNodeArrayToInsert];
   } else if (nodeOrNodeArrayToInsert.length === 1) {
@@ -318,7 +318,7 @@ FastForEach.prototype.shouldDelayDeletion = function (data) {
 // gets the pending deletion info for this data item
 FastForEach.prototype.getPendingDeleteFor = function (data) {
   var index = data && data[PENDING_DELETE_INDEX_KEY];
-  if (typeof index === "undefined") return null;
+  if (index === undefined) return null;
   return this.pendingDeletes[index];
 }
 
@@ -381,7 +381,7 @@ FastForEach.prototype.flushPendingDeletes = function () {
     while (pd.nodesets.length) {
       this.removeNodes(pd.nodesets.pop());
     }
-    if (pd.data && typeof pd.data[PENDING_DELETE_INDEX_KEY] !== "undefined")
+    if (pd.data && pd.data[PENDING_DELETE_INDEX_KEY] !== undefined)
       delete pd.data[PENDING_DELETE_INDEX_KEY];
   }
   this.pendingDeletes.length = 0;
@@ -438,8 +438,7 @@ ko.bindingHandlers.fastForEach = {
         $context: context
       });
     }
-    if (FastForEach.DEBUG)
-      element.ffe = ffe;
+    
     ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
       ffe.dispose();
     });

--- a/index.js
+++ b/index.js
@@ -57,45 +57,19 @@ function valueToChangeAddItem(value, index) {
   };
 }
 
-/*
-  There are two common cases when we should treat additions as adjacent:
-
-    1. two adjacent additions (i.e. contiguous indexes);
-    2. two additions separated by a deletion.
-
-  The second case shall occur, perhaps often, when using the splice method or
-  redefining an array.
-
-  One could theoretically walk backwards through the changes and form a longest-
-  contiguous list of additions, but that *could* be O(n)ish worst case (though
-  average case is probably quite good).
-  */
-function isAdditionAdjacentToLast(changeIndex, arrayChanges) {
-  var change = arrayChanges[changeIndex];
-  var prevChange = arrayChanges[changeIndex - 1];
-
-  if (changeIndex === 0 ||
-      changeIndex >= arrayChanges.length ||
-      change.status !== 'added'
-    ) { return false; }
-
-  // Add-Add
-  if (prevChange.status === 'added' && prevChange.index === change.index - 1) {
-    return true;
+function arrayClear(array) {
+  while (array.length) {
+    array.pop();
   }
-
-  // Add-Del-Add
-  var prevPrevChange = arrayChanges[changeIndex - 2];
-  if (prevPrevChange &&
-    prevChange.status === 'deleted' &&
-    prevChange.index === change.index &&
-    prevPrevChange.status === "added" &&
-    prevPrevChange.index === change.index - 1
-  ) { return true; }
-
-  return false;
 }
 
+// KO 3.4 doesn't seem to export this util function so it's here just for sure
+function createSymbolOrString(identifier) {
+  return typeof Symbol === 'function' ? Symbol(identifier) : identifier;
+}
+
+// store a symbol for caching the pending delete info index in the data item objects
+var PENDING_DELETE_INDEX_KEY = createSymbolOrString("_ko_ffe_pending_delete_index");
 
 function FastForEach(spec) {
   this.element = spec.element;
@@ -106,6 +80,8 @@ function FastForEach(spec) {
   this.as = spec.as;
   this.noContext = spec.noContext;
   this.noIndex = spec.noIndex;
+  // allow users to turn off the 'reuse/move DOM nodes' feature
+  this.allowMoveNodes = spec.allowMoveNodes === undefined ? true : spec.allowMoveNodes;
   this.afterAdd = spec.afterAdd;
   this.beforeRemove = spec.beforeRemove;
   this.templateNode = makeTemplateNode(
@@ -117,6 +93,10 @@ function FastForEach(spec) {
   this.firstLastNodesList = [];
   this.indexesToDelete = [];
   this.rendering_queued = false;
+  this.pendingDeletes = [];
+  // for testability purposes only
+  if (FastForEach.DEBUG)
+    this.manualProcessChangeQueue = spec.manualProcessChangeQueue;
 
   // Remove existing content.
   ko.virtualElements.emptyNode(this.element);
@@ -137,6 +117,7 @@ function FastForEach(spec) {
   }
 }
 
+FastForEach.DEBUG = false;
 
 FastForEach.animateFrame = window.requestAnimationFrame || window.webkitRequestAnimationFrame ||
   window.mozRequestAnimationFrame || window.msRequestAnimationFrame ||
@@ -147,6 +128,7 @@ FastForEach.prototype.dispose = function () {
   if (this.changeSubs) {
     this.changeSubs.dispose();
   }
+  this.flushPendingDeletes();
 };
 
 
@@ -157,35 +139,43 @@ FastForEach.prototype.onArrayChange = function (changeSet) {
     added: [],
     deleted: []
   };
+
+  // knockout array change notification index handling:
+  // - sends the original array indexes for deletes
+  // - sends the new array indexes for adds
+  // - sorts them all by index in ascending order
+  // because of this, when checking for possible batch additions, any delete can be between to adds with neighboring indexes, so only additions should be checked
   for (var i = 0, len = changeSet.length; i < len; i++) {
-    // the change is appended to a last change info object when both are 'added' and have indexes next to each other
-    // here I presume that ko is sending changes in monotonic order (in index variable) which happens to be true, tested with push and splice with multiple pushed values
-    if (isAdditionAdjacentToLast(i, changeSet)) {
-      var batchValues = changeMap.added[changeMap.added.length - 1].values;
-      if (!batchValues) {
-        // transform the last addition into a batch addition object
-        var lastAddition = changeMap.added.pop();
-        var batchAddition = {
-          isBatch: true,
-          status: 'added',
-          index: lastAddition.index,
-          values: [lastAddition.value]
-        };
-        batchValues = batchAddition.values;
-        changeMap.added.push(batchAddition);
+
+    if (changeMap.added.length && changeSet[i].status == 'added') {
+      var lastAdd = changeMap.added[changeMap.added.length - 1];
+      var lastIndex = lastAdd.isBatch ? lastAdd.index + lastAdd.values.length - 1 : lastAdd.index;
+      if (lastIndex + 1 == changeSet[i].index) {
+        if (!lastAdd.isBatch) {
+          // transform the last addition into a batch addition object
+          lastAdd = {
+            isBatch: true,
+            status: 'added',
+            index: lastAdd.index,
+            values: [lastAdd.value]
+          };
+          changeMap.added.splice(changeMap.added.length - 1, 1, lastAdd);
+        }
+        lastAdd.values.push(changeSet[i].value);
+        continue;
       }
-      batchValues.push(changeSet[i].value);
-    } else {
-      changeMap[changeSet[i].status].push(changeSet[i]);
     }
+
+    changeMap[changeSet[i].status].push(changeSet[i]);
   }
+
   if (changeMap.deleted.length > 0) {
     this.changeQueue.push.apply(this.changeQueue, changeMap.deleted);
     this.changeQueue.push({ status: 'clearDeletedIndexes' });
   }
   this.changeQueue.push.apply(this.changeQueue, changeMap.added);
   // Once a change is registered, the ticking count-down starts for the processQueue.
-  if (this.changeQueue.length > 0 && !this.rendering_queued) {
+  if (this.changeQueue.length > 0 && !this.rendering_queued && !this.manualProcessChangeQueue) {
     this.rendering_queued = true;
     FastForEach.animateFrame.call(window, function () { self.processQueue(); });
   }
@@ -210,6 +200,7 @@ FastForEach.prototype.processQueue = function () {
     self[changeItem.status](changeItem);
     // console.log("  ==> ", JSON.stringify($(self.element).text()))
   });
+  this.flushPendingDeletes();
   this.rendering_queued = false;
 
   // Update our indexes.
@@ -239,22 +230,31 @@ FastForEach.prototype.added = function (changeItem) {
   var allChildNodes = [];
 
   for (var i = 0, len = valuesToAdd.length; i < len; ++i) {
-    var templateClone = this.templateNode.cloneNode(true);
-    var childContext;
+    var childNodes;
 
-    if (this.noContext) {
-      childContext = this.$context.extend({
-        $item: valuesToAdd[i],
-        $index: this.noIndex ? undefined : ko.observable()
-      });
+    // we check if we have a pending delete with reusable nodesets for this data, and if yes, we reuse one nodeset
+    var pendingDelete = this.getPendingDeleteFor(valuesToAdd[i]);
+    if (pendingDelete && pendingDelete.nodesets.length) {
+      childNodes = pendingDelete.nodesets.pop();
     } else {
-      childContext = this.$context.createChildContext(valuesToAdd[i], this.as || null, this.noIndex ? undefined : extendWithIndex);
+      var templateClone = this.templateNode.cloneNode(true);
+      var childContext;
+
+      if (this.noContext) {
+        childContext = this.$context.extend({
+          $item: valuesToAdd[i],
+          $index: this.noIndex ? undefined : ko.observable()
+        });
+      } else {
+        childContext = this.$context.createChildContext(valuesToAdd[i], this.as || null, this.noIndex ? undefined : extendWithIndex);
+      }
+
+      // apply bindings first, and then process child nodes, because bindings can add childnodes
+      ko.applyBindingsToDescendants(childContext, templateClone);
+
+      childNodes = ko.virtualElements.childNodes(templateClone);
     }
 
-    // apply bindings first, and then process child nodes, because bindings can add childnodes
-    ko.applyBindingsToDescendants(childContext, templateClone);
-
-    var childNodes = ko.virtualElements.childNodes(templateClone);
     // Note discussion at https://github.com/angular/angular.js/issues/7851
     allChildNodes.push.apply(allChildNodes, Array.prototype.slice.call(childNodes));
     this.firstLastNodesList.splice(index + i, 0, { first: childNodes[0], last: childNodes[childNodes.length - 1] });
@@ -321,22 +321,61 @@ FastForEach.prototype.insertAllAfter = function (nodeOrNodeArrayToInsert, insert
   return nodeOrNodeArrayToInsert;
 };
 
+// checks if the deleted data item should be handled with delay for a possible reuse at additions
+FastForEach.prototype.shouldDelayDeletion = function (data) {
+  return this.allowMoveNodes && typeof data === "object" || typeof data === "function";
+}
+
+// get the cached index from the data item which points to its pendind deletion info
+FastForEach.prototype.getPenndingDeleteIndex = function (data) {
+  var index = data && data[PENDING_DELETE_INDEX_KEY];
+  if (typeof index === "undefined") return -1;
+  return index;
+}
+
+// gets the pending deletion info for this data item
+FastForEach.prototype.getPendingDeleteFor = function (data) {
+  var index = this.getPenndingDeleteIndex(data);
+  if (index < 0) return null;
+  return this.pendingDeletes[index];
+}
+
+// tries to find the existing pending delete info for this data item, and if it can't, it registeres one
+FastForEach.prototype.getOrCreatePendingDeleteFor = function (data) {
+  var pd = this.getPendingDeleteFor(data);
+  if (pd) return pd;
+  pd = {
+    data: data,
+    nodesets: []
+  };
+  data[PENDING_DELETE_INDEX_KEY] = this.pendingDeletes.length;
+  this.pendingDeletes.push(pd);
+  return pd;
+}
 
 // Process a changeItem with {status: 'deleted', ...}
 FastForEach.prototype.deleted = function (changeItem) {
-  var index = changeItem.index,
-    beforeRemoveReturn,
-    nodesToRemove = this.getNodesForIndex(index);
+  // if we should delay the deletion of this data, we add the nodeset to the pending delete info object
+  if (this.shouldDelayDeletion(changeItem.value)) {
+    var pd = this.getOrCreatePendingDeleteFor(changeItem.value);
+    pd.nodesets.push(this.getNodesForIndex(changeItem.index));
+  } else { // simple data, just remove the nodes
+    this.removeNodes(this.getNodesForIndex(changeItem.index));
+  }
+  this.indexesToDelete.push(changeItem.index);
+};
 
+// removes a set of nodes from the DOM
+FastForEach.prototype.removeNodes = function (nodes) {
   var removeFn = function () {
-    ko.utils.arrayForEach(nodesToRemove, function (n) {
+    ko.utils.arrayForEach(nodes, function (n) {
       ko.removeNode(n);
     });
   };
 
-  if (this.beforeRemove && nodesToRemove.length) {
-    beforeRemoveReturn = this.beforeRemove({
-      nodesToRemove: nodesToRemove, foreachInstance: this
+  if (this.beforeRemove && nodes.length) {
+    var beforeRemoveReturn = this.beforeRemove({
+      nodesToRemove: nodes, foreachInstance: this
     }) || {};
     // If beforeRemove returns a `then`–able e.g. a Promise, we remove
     // the nodes when that thenable completes.  We pass any errors to
@@ -344,13 +383,24 @@ FastForEach.prototype.deleted = function (changeItem) {
     if (typeof beforeRemoveReturn.then === 'function') {
       beforeRemoveReturn.then(removeFn, ko.onError ? ko.onError : undefined);
     }
-  } else if (nodesToRemove.length) {
+  } else if (nodes.length) {
     removeFn();
   }
+}
 
-  this.indexesToDelete.push(index);
-};
-
+// flushes the pending delete info store
+// this should be called after queue processing has finished, so that data items and remaining (not reused) nodesets get cleaned up
+// we also call it on dispose not to leave any mess
+FastForEach.prototype.flushPendingDeletes = function () {
+  for (var i = 0; i != this.pendingDeletes.length; ++i) {
+    while (this.pendingDeletes[i].nodesets.length) {
+      this.removeNodes(this.pendingDeletes[i].nodesets.pop());
+      if (this.pendingDeletes[i].data && typeof this.pendingDeletes[i].data[PENDING_DELETE_INDEX_KEY] !== "undefined")
+        delete this.pendingDeletes[i].data[PENDING_DELETE_INDEX_KEY];
+    }
+  }
+  arrayClear(this.pendingDeletes);
+}
 
 // We batch our deletion of item indexes in our parallel array.
 // See brianmhunt/knockout-fast-foreach#6/#8
@@ -403,6 +453,8 @@ ko.bindingHandlers.fastForEach = {
         $context: context
       });
     }
+    if (FastForEach.DEBUG)
+      element.ffe = ffe;
     ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
       ffe.dispose();
     });

--- a/index.js
+++ b/index.js
@@ -351,7 +351,9 @@ FastForEach.prototype.deleted = function (changeItem) {
 
 // removes a set of nodes from the DOM
 FastForEach.prototype.removeNodes = function (nodes) {
-  if (!nodes.length) return;
+  if (!nodes.length) {
+    return;
+  }
 
   var removeFn = function () {
     ko.utils.arrayForEach(nodes, function (n) { ko.removeNode(n); });
@@ -384,7 +386,7 @@ FastForEach.prototype.flushPendingDeletes = function () {
     if (pd.data && pd.data[PENDING_DELETE_INDEX_KEY] !== undefined)
       delete pd.data[PENDING_DELETE_INDEX_KEY];
   }
-  this.pendingDeletes.length = 0;
+  this.pendingDeletes = [];
 }
 
 // We batch our deletion of item indexes in our parallel array.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "./node_modules/karma/bin/karma start --single-run --browsers Chrome,PhantomJS,Firefox",
     "watch": "./node_modules/karma/bin/karma start --browsers PhantomJS",
-    "test_win": "node_modules\\.bin\\karma.cmd start --single-run --browsers Chrome,PhantomJS,Firefox"
+    "test_win": "node_modules\\.bin\\karma.cmd start --single-run --browsers Chrome,PhantomJS,Firefox",
+    "test_win_chrome_debug": "node_modules\\.bin\\karma.cmd start --auto-watch --browsers Chrome"
   },
   "repository": {
     "type": "git",

--- a/spec/knockout-fast-foreach-spec.js
+++ b/spec/knockout-fast-foreach-spec.js
@@ -393,7 +393,10 @@ describe("observable array changes", function () {
     it("emits on remove", function () {
       var cbi = 0;
       var arr = ko.observableArray(['a1', 'b1', 'c1'])
-      function cb(v) { ko.removeNode(v.nodeToRemove); cbi++; }
+      function cb(v) {
+        ko.utils.arrayForEach(v.nodesToRemove, function (n) { ko.removeNode(n); });
+        cbi++;
+      }
       var target = $("<ul data-bind='fastForEach: { data: arr, beforeRemove: cb }'><li data-bind='text: $data'></li></div>");
       ko.applyBindings({arr: arr, cb: cb}, target[0])
       assert.equal(cbi, 0)

--- a/spec/knockout-fast-foreach-spec.js
+++ b/spec/knockout-fast-foreach-spec.js
@@ -469,7 +469,7 @@ describe("observable array changes", function () {
         element: div[0],
         data: obs,
         $context: ko.contextFor(div[0]),
-        templateNode: $("<script type='text/html'><div data-bind='html: testHtml'></div></script>")[0]
+        templateNode: $("<template><div data-bind='html: testHtml'></div></template>")[0]
       });
 
       ffe.processQueue();

--- a/spec/knockout-fast-foreach-spec.js
+++ b/spec/knockout-fast-foreach-spec.js
@@ -373,8 +373,10 @@ describe("observable array changes", function () {
     })
 
     it("Sort large complex array makes correct DOM moves", function() {
-      this.timeout(50000);
-      var itemNumber = 1000;
+      // for performance testing
+      //this.timeout(50000);
+      //var itemNumber = 1000;
+      var itemNumber = 100;
       div = $("<div data-bind='fastForEach: { data: obs }'><div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div></div></div>");
       ko.applyBindings(view, div[0]);
       var arr = [], i;
@@ -398,8 +400,10 @@ describe("observable array changes", function () {
     })
 
     it("Sort large complex array makes correct DOM order without move", function() {
-      this.timeout(50000);
-      var itemNumber = 1000;
+      // for performance testing
+      //this.timeout(50000);
+      //var itemNumber = 1000;
+      var itemNumber = 100;
       div = $("<div data-bind='fastForEach: { data: obs, allowMoveNodes: false }'><div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div></div></div>");
       ko.applyBindings(view, div[0]);
       var arr = [], i;
@@ -513,37 +517,6 @@ describe("observable array changes", function () {
       assert.equal(div.text(), 'CAB')
     })
   })
-
-  //describe("isAdditionAdjacentToLast", function () {
-  //  it("is false for a deletion", function () {
-  //    assert.notOk(isAdditionAdjacentToLast(0, [{status: 'deleted'}]))
-  //  })
-
-  //  it("is false for a single addition", function () {
-  //    assert.notOk(isAdditionAdjacentToLast(0, [{status: 'added'}]))
-  //  })
-
-  //  it("is true for two adjacent additions", function () {
-  //    assert.ok(isAdditionAdjacentToLast(1,
-  //      [{status: 'added', index: 0}, {status: 'added', index: 1}]))
-  //  })
-
-  //  it("is true for adds separated by a del", function () {
-  //    assert.ok(isAdditionAdjacentToLast(2, [
-  //      {status: 'added', index: 0},
-  //      {status: 'deleted', index: 1},
-  //      {status: 'added', index: 1},
-  //    ]))
-  //  })
-
-  //  it("is false for adds with differing del index", function () {
-  //    assert.notOk(isAdditionAdjacentToLast(2, [
-  //      {status: 'added', index: 0},
-  //      {status: 'deleted', index: 0},
-  //      {status: 'added', index: 1},
-  //    ]))
-  //  })
-  //})
 
   describe('afterAdd', function () {
     it("emits on changes to an observable array", function () {

--- a/spec/knockout-fast-foreach-spec.js
+++ b/spec/knockout-fast-foreach-spec.js
@@ -333,13 +333,13 @@ describe("observable array changes", function () {
       div = $("<div data-bind='fastForEach: obs'><div data-bind='html: testHtml'></div></div>");
       ko.applyBindings(view, div[0]);
       obs([{ id: 4, testHtml: '<span>A</span>' }, { id: 6, testHtml: '<span>B</span>' }, { id: 1, testHtml: '<span>C</span>' }])
-      var nodes = div.children().each(function(i) { this.id = i; }).toArray()
+      var nodes = div.children().toArray()
       assert.equal(div.text(), 'ABC')
       obs.sort(function(a, b) { return a.id - b.id; })
       var nodes2 = div.children().toArray()
-      assert.equal(nodes[1].id, nodes2[2].id)
-      assert.equal(nodes[2].id, nodes2[0].id)
-      assert.equal(nodes[0].id, nodes2[1].id)
+      assert.strictEqual(nodes[1], nodes2[2])
+      assert.strictEqual(nodes[2], nodes2[0])
+      assert.strictEqual(nodes[0], nodes2[1])
       assert.equal(div.text(), 'CAB')
     })
 
@@ -347,35 +347,35 @@ describe("observable array changes", function () {
       div = $("<div data-bind='fastForEach: obs'><div data-bind='html: testHtml'></div></div>");
       ko.applyBindings(view, div[0]);
       obs([{ id: 7, testHtml: '<span>A</span>' }, { id: 6, testHtml: '<span>B</span>' }, { id: 1, testHtml: '<span>C</span>' }, { id: 9, testHtml: '<span>D</span>' }])
-      var nodes = div.children().each(function(i) { this.id = i; }).toArray()
+      var nodes = div.children().toArray()
       assert.equal(div.text(), 'ABCD')
       obs.reverse();
       var nodes2 = div.children().toArray()
-      assert.equal(nodes[0].id, nodes2[3].id)
-      assert.equal(nodes[1].id, nodes2[2].id)
-      assert.equal(nodes[2].id, nodes2[1].id)
-      assert.equal(nodes[3].id, nodes2[0].id)
+      assert.strictEqual(nodes[0], nodes2[3])
+      assert.strictEqual(nodes[1], nodes2[2])
+      assert.strictEqual(nodes[2], nodes2[1])
+      assert.strictEqual(nodes[3], nodes2[0])
       assert.equal(div.text(), 'DCBA')
     })
 
-    it("sorting complex data recreates DOM nodes if move disabled", function() {
-      div = $("<div data-bind='fastForEach: { data: obs, allowMoveNodes: false }'><div data-bind='html: testHtml'></div></div>");
+    it("sorting complex data recreates DOM nodes if move disabled", function () {
+      var originalShouldDelayDeletion = FastForEach.prototype.shouldDelayDeletion;
+      FastForEach.prototype.shouldDelayDeletion = function(data) { return false; }
+      div = $("<div data-bind='fastForEach: { data: obs }'><div data-bind='html: testHtml'></div></div>");
       ko.applyBindings(view, div[0]);
       obs([{ id: 7, testHtml: '<span>A</span>' }, { id: 6, testHtml: '<span>B</span>' }, { id: 1, testHtml: '<span>C</span>' }])
-      var nodes = div.children().each(function(i) { this.id = i; }).toArray()
+      var nodes = div.children().toArray()
       assert.equal(div.text(), 'ABC')
       obs.sort(function(a, b) { return a.id - b.id; })
       var nodes2 = div.children().toArray()
       assert.equal(div.text(), 'CBA')
-      assert.notEqual(nodes[1].id, nodes2[2].id)
-      assert.notEqual(nodes[2].id, nodes2[0].id)
-      assert.notEqual(nodes[0].id, nodes2[1].id)
+      assert.notStrictEqual(nodes[1], nodes2[2])
+      assert.notStrictEqual(nodes[2], nodes2[0])
+      assert.notStrictEqual(nodes[0], nodes2[1])
+      FastForEach.prototype.shouldDelayDeletion = originalShouldDelayDeletion;
     })
 
     it("Sort large complex array makes correct DOM moves", function() {
-      // for performance testing
-      //this.timeout(50000);
-      //var itemNumber = 1000;
       var itemNumber = 100;
       div = $("<div data-bind='fastForEach: { data: obs }'><div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div></div></div>");
       ko.applyBindings(view, div[0]);
@@ -400,11 +400,10 @@ describe("observable array changes", function () {
     })
 
     it("Sort large complex array makes correct DOM order without move", function() {
-      // for performance testing
-      //this.timeout(50000);
-      //var itemNumber = 1000;
+      var originalShouldDelayDeletion = FastForEach.prototype.shouldDelayDeletion;
+      FastForEach.prototype.shouldDelayDeletion = function (data) { return false; }
       var itemNumber = 100;
-      div = $("<div data-bind='fastForEach: { data: obs, allowMoveNodes: false }'><div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div></div></div>");
+      div = $("<div data-bind='fastForEach: { data: obs }'><div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div><div data-bind='html: testHtml'></div></div></div>");
       ko.applyBindings(view, div[0]);
       var arr = [], i;
       for (i = 0; i != itemNumber; ++i) {
@@ -412,10 +411,7 @@ describe("observable array changes", function () {
       }
       obs(arr)
       assert.equal(div.children().length, itemNumber)
-      div.children().prop("testprop", 10)
-      console.time("without move");
       obs.sort(function(a, b) { return a.id - b.id; })
-      console.timeEnd("without move");
       for (i = 0; i != itemNumber; ++i) {
         arr[i].num = i;
       }
@@ -423,6 +419,7 @@ describe("observable array changes", function () {
       div.children().each(function(index) {
         assert.equal(index, ko.dataFor(this).num)
       })
+      FastForEach.prototype.shouldDelayDeletion = originalShouldDelayDeletion;
     })
 
     it("processes duplicate data 1", function () {
@@ -435,8 +432,8 @@ describe("observable array changes", function () {
       assert.equal(div.text(), 'BAAA')
       obs([itemA, itemB])
       var nodes2 = div.children().toArray()
-      assert.equal(nodes[3], nodes2[0])
-      assert.equal(nodes[0], nodes2[1])
+      assert.strictEqual(nodes[3], nodes2[0])
+      assert.strictEqual(nodes[0], nodes2[1])
       assert.equal(div.text(), 'AB')
     })
 
@@ -459,7 +456,9 @@ describe("observable array changes", function () {
     })
 
     it("processes changes from more changesets 1", function () {
-      div = $("<div data-bind='fastForEach: { data: obs, manualProcessChangeQueue: true }'><div data-bind='html: testHtml'></div></div>");
+      var originalAnimateFrame = FastForEach.animateFrame;
+      FastForEach.animateFrame = function() { };
+      div = $("<div data-bind='fastForEach: { data: obs }'><div data-bind='html: testHtml'></div></div>");
       ko.applyBindings(view, div[0]);
       var itemA = { id: 4, testHtml: '<span>A</span>' };
       var others = [11, 12, 13, 14].map(function (e) { return { id: e, testHtml: 'C'+e } });
@@ -475,10 +474,13 @@ describe("observable array changes", function () {
       assert.equal(div.text(), "C14C13C12A")
       // moved all five nodes around
       assert.equal(div.children().filter(function () { return this.test == 1; }).length, 4)
+      FastForEach.animateFrame = originalAnimateFrame;
     })
 
     it("processes changes from more changesets 2", function () {
-      div = $("<div data-bind='fastForEach: { data: obs, manualProcessChangeQueue: true }'><div data-bind='html: testHtml'></div></div>");
+      var originalAnimateFrame = FastForEach.animateFrame;
+      FastForEach.animateFrame = function () { };
+      div = $("<div data-bind='fastForEach: { data: obs }'><div data-bind='html: testHtml'></div></div>");
       ko.applyBindings(view, div[0]);
       var itemA = { id: 4, testHtml: '<span>A</span>' };
       var itemB = { id: 5, testHtml: '<span>B</span>' };
@@ -495,8 +497,8 @@ describe("observable array changes", function () {
       assert.equal(div.text(), "AB")
       div[0].ffe.processQueue();
       assert.equal(div.text(), "AB")
-      // moved all five nodes around
       assert.equal(div.children().filter(function () { return this.test == 1; }).length, 2)
+      FastForEach.animateFrame = originalAnimateFrame;
     })
 
     it("cleans data objects", function () {

--- a/spec/knockout-fast-foreach-spec.js
+++ b/spec/knockout-fast-foreach-spec.js
@@ -494,6 +494,24 @@ describe("observable array changes", function () {
       // moved all five nodes around
       assert.equal(div.children().filter(function () { return this.test == 1; }).length, 2)
     })
+
+    it("cleans data objects", function () {
+      div = $("<div data-bind='fastForEach: obs'><div data-bind='html: testHtml'></div></div>");
+      ko.applyBindings(view, div[0]);
+      var itemA = { id: 4, testHtml: '<span>A</span>' };
+      var itemB = { id: 6, testHtml: '<span>B</span>' };
+      var itemC = { id: 6, testHtml: '<span>C</span>' };
+      obs([itemA, itemB, itemC, itemA])
+      var nodes = div.children().toArray()
+      assert.equal(div.text(), 'ABCA')
+      obs([itemC, itemA, itemB])
+      var nodes2 = div.children().toArray()
+      assert.equal(itemA[FastForEach.PENDING_DELETE_INDEX_KEY], undefined)
+      assert.equal(itemB[FastForEach.PENDING_DELETE_INDEX_KEY], undefined)
+      assert.equal(itemC[FastForEach.PENDING_DELETE_INDEX_KEY], undefined)
+      assert.equal(nodes[0], nodes2[1])
+      assert.equal(div.text(), 'CAB')
+    })
   })
 
   //describe("isAdditionAdjacentToLast", function () {


### PR DESCRIPTION
With this feature, on every array operation which results moving of several items FastForEach will detect these moves and will not remove/recreate the corresponding DOM structure, but simply move that too. 

Scenarios where this is extremely useful:
- splice
- sort
- direct observable array reassignments
- consecutive array manipulations within one FastForEach UI update cycle
