### PR TITLE
Extending child contexts with container element

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,12 +204,6 @@ FastForEach.prototype.processQueue = function () {
   this.changeQueue = [];
 };
 
-
-function extendWithIndex(context) {
-  context.$index = ko.observable();
-};
-
-
 // Process a changeItem with {status: 'added', ...}
 FastForEach.prototype.added = function (changeItem) {
   var index = changeItem.index;
@@ -227,19 +221,9 @@ FastForEach.prototype.added = function (changeItem) {
       childNodes = pendingDelete.nodesets.pop();
     } else {
       var templateClone = this.templateNode.cloneNode(true);
-      var childContext;
-
-      if (this.noContext) {
-        childContext = this.$context.extend({
-          $item: valuesToAdd[i],
-          $index: this.noIndex ? undefined : ko.observable()
-        });
-      } else {
-        childContext = this.$context.createChildContext(valuesToAdd[i], this.as || null, this.noIndex ? undefined : extendWithIndex);
-      }
-
+      
       // apply bindings first, and then process child nodes, because bindings can add childnodes
-      ko.applyBindingsToDescendants(childContext, templateClone);
+      ko.applyBindingsToDescendants(this.createChildContext(valuesToAdd[i]), templateClone);
 
       childNodes = ko.virtualElements.childNodes(templateClone);
     }
@@ -258,6 +242,23 @@ FastForEach.prototype.added = function (changeItem) {
   } else {
     this.insertAllAfter(allChildNodes, referenceElement);
   }
+};
+
+FastForEach.prototype.createChildContext = function(data) {
+  var childContext, self = this;
+  if (this.noContext) {
+    childContext = this.$context.extend({
+      $item: data,
+      $index: this.noIndex ? undefined : ko.observable(),
+      $container: this.container
+  });
+  } else {
+    childContext = this.$context.createChildContext(data, this.as || null, this.noIndex ? undefined : function extendWithIndex(context) {
+      context.$index = ko.observable();
+      context.$container = self.container
+    });
+  }
+  return childContext;
 };
 
 FastForEach.prototype.getNodesForIndex = function (index) {

--- a/index.js
+++ b/index.js
@@ -250,12 +250,12 @@ FastForEach.prototype.createChildContext = function(data) {
     childContext = this.$context.extend({
       $item: data,
       $index: this.noIndex ? undefined : ko.observable(),
-      $container: this.container
+      $parentNode: this.container
   });
   } else {
     childContext = this.$context.createChildContext(data, this.as || null, this.noIndex ? undefined : function extendWithIndex(context) {
       context.$index = ko.observable();
-      context.$container = self.container
+      context.$parentNode = self.container
     });
   }
   return childContext;


### PR DESCRIPTION
This change addresses #39 by extending the child binding context with a `$parentNode` property. The `$parentNode` property refers to the - not virtual - container node, which will become the parent node of each item.

General usage recommendation for custom bindings which need to access the parent element can be like this.

```
var parentNode = context.$parentNode || element.parentNode;
```

This technique could be kind of a _default workaround_ for any binding which control child bindings and have such a complex logic that the child nodes are not attached to the DOM yet at binding time.

As far as `FastForEach` goes, it would have been very difficoult to implement a logic to insert the child nodes first, and then bind them.

I'm open to any other idea.
