### PR TITLE
Null check for empty data

### DIFF
--- a/dist/knockout-fast-foreach.js
+++ b/dist/knockout-fast-foreach.js
@@ -107,10 +107,10 @@ function FastForEach(spec) {
   ko.virtualElements.emptyNode(this.element);
 
   // Prime content
-    var primeData = ko.unwrap(this.data);
-    if (primeData && primeData.map) {
-      this.onArrayChange(primeData.map(valueToChangeAddItem));
-    }
+  var primeData = ko.unwrap(this.data);
+  if (primeData && primeData.map) {
+    this.onArrayChange(primeData.map(valueToChangeAddItem), true);
+  }
 
   // Watch for changes
   if (ko.isObservable(this.data)) {

--- a/dist/knockout-fast-foreach.js
+++ b/dist/knockout-fast-foreach.js
@@ -107,10 +107,10 @@ function FastForEach(spec) {
   ko.virtualElements.emptyNode(this.element);
 
   // Prime content
-  var primeData = ko.unwrap(this.data);
-  if (primeData.map) {
-    this.onArrayChange(primeData.map(valueToChangeAddItem), true);
-  }
+    var primeData = ko.unwrap(this.data);
+    if (primeData && primeData.map) {
+      this.onArrayChange(primeData.map(valueToChangeAddItem));
+    }
 
   // Watch for changes
   if (ko.isObservable(this.data)) {


### PR DESCRIPTION
i have encountered errors whist using fastforeach with lists that may or may not contain nested children. With the `this.data` property being blank causing the loop to crash. This null check allows this to process only when required. 